### PR TITLE
Fix broken image URL causing 404 error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,7 +238,7 @@ function App() {
 
             <div className="relative">
               <img 
-                src="https://images.unsplash.com/photo-1635424824849-c5b5e8b6e8e8?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80" 
+                src="https://cdn.pixabay.com/photo/2015/09/17/12/04/solar-panels-943999_960_720.jpg" 
                 alt="Профессиональные кровельщики за работой"
                 className="rounded-lg shadow-lg w-full"
               />


### PR DESCRIPTION
- Replaced broken Unsplash image with working Pixabay URL
- Image now loads correctly: https://cdn.pixabay.com/photo/2015/09/17/12/04/solar-panels-943999_960_720.jpg
- Fixes 404 error reported by user in advantages section
- Tested locally and image displays properly